### PR TITLE
fix: change result name fail to failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Check All CI Completion checks if all launched CIs are successful or not. This m
 
 | name   | value                           | description                                                                  |
 | ------ | ------------------------------- | ---------------------------------------------------------------------------- |
-| result | null / success / fail           | another CI job result(if all jobs are success or neutral, result is success) |
+| result | null / success / failure        | another CI job result(if all jobs are success or neutral, result is success) |
 | status | null / completed / in-progress  | another CI job status                                                        |
 
 ### Full yaml (for main branch)

--- a/README_jp.md
+++ b/README_jp.md
@@ -52,7 +52,7 @@ Check All CI Completion では、すべての起動した CI が成功してい�
 
 | name   | value                           | description                                                                              |
 | ------ | ------------------------------- | ---------------------------------------------------------------------------------------- |
-| result | null / success / fail           | 別の CI ジョブの結果（すべてのジョブが success または neutralの場合、結果は success です |
+| result | null / success / failure        | 別の CI ジョブの結果（すべてのジョブが success または neutralの場合、結果は success です |
 | status | null / completed / in-progress  | 別の CI ジョブのステータスです                                                           |
 
 ### Full yaml (for main branch)

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ inputs:
     default: '30'
 outputs:
   result:
-    description: 'the RESULT of the specific check-suites (success or fail)'
+    description: 'the RESULT of the specific check-suites (success or failure)'
     value: ${{ steps.check-ci-statuses.outputs.result }}
   status:
     description: 'the STATUS of the specific check-suites (completed or in-progress)'
@@ -108,7 +108,7 @@ runs:
                 | .conclusion" \
             | sort \
             | uniq \
-            | grep -v -E "(success|neutral)" && RESULT="fail" || RESULT="success"
+            | grep -v -E "(success|neutral)" && RESULT="failure" || RESULT="success"
 
         # output
         [[ "${STATUS}" = "completed" ]] || STATUS="in-progress"


### PR DESCRIPTION
**This is breaking change!!**

GitHub Check Suite use these conclusion

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/10017674/154421758-3400c369-cc4a-4296-a3fe-a774bb788bc1.png">

So fix name.
