### PR TITLE
always success check if all job skipped

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -112,7 +112,7 @@ runs:
             sleep $SLEEP_SECONDS
         done
 
-        # if all check-suites results are success or neutral, this ci is success
+        # if all check-suites results are success or neutral or skipped, this ci is success
         # https://docs.github.com/ja/rest/guides/getting-started-with-the-checks-api#about-check-suites
         gh api "repos/${GITHUB_REPOSITORY}/commits/${SPECIFIC_COMMIT_HASH}/check-suites" \
             | jq -r ".check_suites[] \
@@ -124,7 +124,7 @@ runs:
                 | .conclusion" \
             | sort \
             | uniq \
-            | grep -v -E "(success|neutral)" && RESULT="failure" || RESULT="success"
+            | grep -v -E "(success|neutral|skipped)" && RESULT="failure" || RESULT="success"
 
         # output
         [[ "${STATUS}" = "completed" ]] || STATUS="in-progress"


### PR DESCRIPTION
`check-all-ci-completion-action` fails if all PR jobs are skipped.
This PR implemented that `check-all-ci-completion-action` always successed if all job is skipped

ref: [check suites conclusion](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks?apiVersion=2022-11-28#about-check-suites)